### PR TITLE
Enh/leaflet map styles

### DIFF
--- a/src/App.module.scss
+++ b/src/App.module.scss
@@ -1,12 +1,9 @@
 @import 'index';
 
 .app {
-  background-image: url('https://upload.wikimedia.org/wikipedia/commons/d/de/China_Hong_Kong_location_map.svg');
-  background-size: cover;
   height: 100%;
 
   > div[tabindex="0"] {
-    height: 100%;
     background-color: get-color(black);
   }
 }

--- a/src/components/DrawerContainer/DrawerContainer.module.scss
+++ b/src/components/DrawerContainer/DrawerContainer.module.scss
@@ -11,6 +11,7 @@
 .drawer-horizontal {
   > div[tabindex="-1"] {
     background-color: rgba(get-color(brown), 0.7);
-    width: 300px;
+    width: calc(100% - 20px);
+    max-width: 405px;
   }
 }

--- a/src/components/Map/Map.module.scss
+++ b/src/components/Map/Map.module.scss
@@ -1,0 +1,11 @@
+@import 'css/main';
+
+.tile-layer {
+  filter: contrast(1.4) hue-rotate(260deg) saturate(1.3) brightness(0.8);
+}
+
+.icon {
+  background-color: rgba(get-color(white), 0.9);
+  border-radius: 50%;
+  box-shadow: inset 0px 0px 3px 3px get-color(gold), 0px 0px 5px 5px rgba(get-color(gold), 0.9);
+}

--- a/src/components/Map/constant.ts
+++ b/src/components/Map/constant.ts
@@ -1,0 +1,16 @@
+import L from 'leaflet';
+
+export const urlTemplate: string =
+  'https://tiles.stadiamaps.com/tiles/alidade_smooth_dark/{z}/{x}/{y}{r}.png';
+
+export const attribution: string =
+  '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a>, &copy; <a href="https://openmaptiles.org/">OpenMapTiles</a> &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors';
+
+export const options: L.MapOptions = {
+  center: [22.2988, 114.1722],
+  zoom: 12,
+  zoomSnap: 0.1,
+  zoomDelta: 0.5,
+  zoomControl: false,
+  doubleClickZoom: false
+};

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import L from 'leaflet';
+import classes from './Map.module.scss';
 
 interface IMapProps {
   markersData: [number, number][];
@@ -8,6 +9,7 @@ interface IMapProps {
 const Map: React.FC<IMapProps> = (props: IMapProps) => {
   const mapRef: React.MutableRefObject<L.Map | null> = useRef(null);
   const layerRef: React.MutableRefObject<L.LayerGroup | null> = useRef(null);
+  const divIcon: L.DivIcon = L.divIcon({ className: classes.icon });
 
   useEffect(() => {
     mapRef.current = L.map('map', {
@@ -18,10 +20,14 @@ const Map: React.FC<IMapProps> = (props: IMapProps) => {
       zoomControl: false,
       doubleClickZoom: false,
       layers: [
-        L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
-          attribution:
-            '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-        })
+        L.tileLayer(
+          'https://tiles.stadiamaps.com/tiles/alidade_smooth_dark/{z}/{x}/{y}{r}.png',
+          {
+            className: classes['tile-layer'],
+            attribution:
+              '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a>, &copy; <a href="https://openmaptiles.org/">OpenMapTiles</a> &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
+          }
+        )
       ]
     });
   }, []);
@@ -33,11 +39,15 @@ const Map: React.FC<IMapProps> = (props: IMapProps) => {
   useEffect(() => {
     (layerRef.current as L.LayerGroup).clearLayers();
     props.markersData.forEach(marker => {
-      L.marker(L.latLng(marker)).addTo(layerRef.current as L.LayerGroup);
+      L.marker(L.latLng(marker), { icon: divIcon })
+        .on('click', event => {
+          (mapRef.current as L.Map).flyTo(L.latLng(marker));
+        })
+        .addTo(layerRef.current as L.LayerGroup);
     });
   });
 
-  return <div id="map" />;
+  return <div id="map" style={{ height: '100%' }} />;
 };
 
 export default Map;

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import L from 'leaflet';
 import classes from './Map.module.scss';
+import { urlTemplate, attribution, options } from './constant';
 
 interface IMapProps {
   markersData: [number, number][];
@@ -9,28 +10,18 @@ interface IMapProps {
 const Map: React.FC<IMapProps> = (props: IMapProps) => {
   const mapRef: React.MutableRefObject<L.Map | null> = useRef(null);
   const layerRef: React.MutableRefObject<L.LayerGroup | null> = useRef(null);
-  const divIcon: L.DivIcon = L.divIcon({ className: classes.icon });
+
+  const icon: L.DivIcon = L.divIcon({ className: classes.icon });
+  const tileLayer: L.TileLayer = L.tileLayer(urlTemplate, {
+    className: classes['tile-layer'],
+    attribution
+  });
+  const mapOptions: L.MapOptions = { ...options, layers: [tileLayer] };
+  const style: React.CSSProperties = { height: '100%' };
 
   useEffect(() => {
-    mapRef.current = L.map('map', {
-      center: [22.2988, 114.1722],
-      zoom: 12,
-      zoomSnap: 0.1,
-      zoomDelta: 0.5,
-      zoomControl: false,
-      doubleClickZoom: false,
-      layers: [
-        L.tileLayer(
-          'https://tiles.stadiamaps.com/tiles/alidade_smooth_dark/{z}/{x}/{y}{r}.png',
-          {
-            className: classes['tile-layer'],
-            attribution:
-              '&copy; <a href="https://stadiamaps.com/">Stadia Maps</a>, &copy; <a href="https://openmaptiles.org/">OpenMapTiles</a> &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
-          }
-        )
-      ]
-    });
-  }, []);
+    mapRef.current = L.map('map', mapOptions);
+  }, [mapOptions]);
 
   useEffect(() => {
     layerRef.current = L.layerGroup().addTo(mapRef.current as L.Map);
@@ -39,15 +30,15 @@ const Map: React.FC<IMapProps> = (props: IMapProps) => {
   useEffect(() => {
     (layerRef.current as L.LayerGroup).clearLayers();
     props.markersData.forEach(marker => {
-      L.marker(L.latLng(marker), { icon: divIcon })
-        .on('click', event => {
+      L.marker(L.latLng(marker), { icon })
+        .on('click', () => {
           (mapRef.current as L.Map).flyTo(L.latLng(marker));
         })
         .addTo(layerRef.current as L.LayerGroup);
     });
   });
 
-  return <div id="map" style={{ height: '100%' }} />;
+  return <div id="map" style={style} />;
 };
 
 export default Map;


### PR DESCRIPTION
### Descriptions
- Restyle `leaflet` map and markers
- References: [`leaflet`](https://leafletjs.com/reference-1.6.0.html), [`react-leaflet`](https://react-leaflet.js.org/), [`example`](https://cherniavskii.com/using-leaflet-in-react-apps-with-react-hooks/)

### Stories
- [x] Style the `markers`
- [x] Change the tile provider to [`Stadia.AlidadeSmoothDark`](http://leaflet-extras.github.io/leaflet-providers/preview/index.html) mimic the UI design
- [x] Style the `tileLayer`
- [x] Add `eventListener` to `markers` to trigger the map view `flyTo` the marker's `latLng` 
- [x] Set `DrawerContainer` width responsive to the viewport width
- [x] Extract `urlTemplate`, `attribution` and `options` from `Map` component to `constant` file

### Screenshots
*Mobile view*
![image](https://user-images.githubusercontent.com/47293355/76980271-f58c7580-6973-11ea-9fa4-adf8b1482bf6.png)

*Tablet view*
![image](https://user-images.githubusercontent.com/47293355/76980300-ff15dd80-6973-11ea-8693-11ae8613b8c3.png)

*Desktop view*
![image](https://user-images.githubusercontent.com/47293355/76980377-12c14400-6974-11ea-9e36-03fda87aed53.png)
