### PR TITLE
Fix/stadia maps api key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 REACT_APP_API_SERVER="http://localhost:8080"
+STADIA_MAP_API_KEY="api_key"

--- a/src/components/Map/constant.ts
+++ b/src/components/Map/constant.ts
@@ -1,9 +1,10 @@
 import L from 'leaflet';
 
+const { STADIA_MAP_API_KEY } = process.env;
+
 const tsimShaTsuiLatLng: [number, number] = [22.2988, 114.1722];
 
-export const urlTemplate: string =
-  'https://tiles.stadiamaps.com/tiles/alidade_smooth_dark/{z}/{x}/{y}{r}.png';
+export const urlTemplate: string = `https://tiles.stadiamaps.com/tiles/alidade_smooth_dark/{z}/{x}/{y}{r}.png?api_key=${STADIA_MAP_API_KEY}`;
 
 export const attribution: string = `
   &copy; <a href="https://stadiamaps.com/">Stadia Maps</a>,


### PR DESCRIPTION
### Descriptions
- Add `api_key` in Stadia maps api requests

### Stories
- [x] Add env variable `STADIA_MAP_API_KEY` in `.env.example`
- [x] Use `STADIA_MAP_API_KEY` as query param in the map api request in `Map` component