### PR TITLE
Enh/ux styles adjustment

### DIFF
--- a/src/components/PlayList/index.tsx
+++ b/src/components/PlayList/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import clsx from 'clsx';
 import VoicePlayer from 'components/VoicePlayer';
 import RecordButton from 'components/RecordButton';
 import { Voice } from 'models';
@@ -7,12 +8,18 @@ import { connect } from 'react-redux';
 import classes from './styles.module.scss';
 
 interface IPlayListProps {
+  open: boolean;
   voices: Array<Voice>;
 }
 
 const PlayList: React.FC<IPlayListProps> = (props: IPlayListProps) => {
   return (
-    <div className={classes['playing-panel']}>
+    <div
+      className={clsx({
+        [classes['play-list']]: true,
+        [classes.open]: props.open
+      })}
+    >
       <ul className={classes.voices}>
         {props.voices.map((voice, idx) => (
           <li key={idx}>

--- a/src/components/PlayList/styles.module.scss
+++ b/src/components/PlayList/styles.module.scss
@@ -1,7 +1,20 @@
 @import 'css/main';
 
-.playing-panel {
-  border-top: 1px solid get-color(white);
+.play-list {
+  max-height: 0;
+  border-top: 1px solid transparent;
+  overflow: hidden;
+  transition:
+    max-height 0.15s ease-out,
+    border-top 0.15s ease-out;
+
+  &.open {
+    max-height: 100%;
+    border-top: 1px solid get-color(white);
+    transition:
+      max-height 0.3s ease-in,
+      border-top 0.3s ease-in;
+  }
 
   .voices {
     list-style: none;

--- a/src/components/ThreadPanel/index.tsx
+++ b/src/components/ThreadPanel/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PlayList from 'components/PlayList';
 import { IconButton } from '@material-ui/core';
 import { FaRegStar, FaPlay, FaPause } from 'react-icons/fa';
@@ -20,14 +20,27 @@ interface IThreadPanelProps {
 }
 
 const ThreadPanel: React.FC<IThreadPanelProps> = (props: IThreadPanelProps) => {
+  const [playListState, setPlayListState] = useState(props.threadPlaying);
+
+  const toggleHasPlayed = () => {
+    setPlayListState(!playListState);
+  };
+
+  const playOrPauseThread = () => {
+    setPlayListState(true);
+    props.toggleThreadPlaying();
+  };
+
   return (
     <div className={classes['thread-panel']}>
       {props.activeThread && (
         <div className={classes.container}>
-          <div className={classes.record} />
+          <div className={classes.handle} onClick={toggleHasPlayed} />
 
           <div className={classes.contents}>
-            <h2 className={classes.title}>{props.activeThread.title}</h2>
+            <h2 className={classes.title} onClick={toggleHasPlayed}>
+              {props.activeThread.title}
+            </h2>
 
             <p className={classes.info}>
               {
@@ -59,7 +72,7 @@ const ThreadPanel: React.FC<IThreadPanelProps> = (props: IThreadPanelProps) => {
                 className={classes['thread-play']}
                 color="inherit"
                 aria-label="play"
-                onClick={props.toggleThreadPlaying}
+                onClick={playOrPauseThread}
               >
                 {props.threadPlaying ? <FaPause /> : <FaPlay />}
               </IconButton>
@@ -81,7 +94,7 @@ const ThreadPanel: React.FC<IThreadPanelProps> = (props: IThreadPanelProps) => {
               </IconButton>
             </div>
 
-            {props.threadPlaying && <PlayList />}
+            {<PlayList open={playListState} />}
           </div>
         </div>
       )}

--- a/src/components/ThreadPanel/styles.module.scss
+++ b/src/components/ThreadPanel/styles.module.scss
@@ -5,12 +5,13 @@
   margin: 0 30px;
 
   .container {
-    .record {
+    .handle {
       margin: 0 auto;
       width: 20px;
       height: 5px;
       background-color: get-color(white);
       border-radius: 5px;
+      cursor: pointer;
     }
 
     .contents {
@@ -19,6 +20,11 @@
       .title {
         margin: 0 0 10px;
         text-align: center;
+        cursor: pointer;
+
+        &:focus {
+          outline: none;
+        }
       }
 
       .info {


### PR DESCRIPTION
### Descriptions
- Add control logic of opening and closing `PlayList` component in `ThreadPanel`
- `PlayList` can be opened or closed by clicking the thread title / handle in `ThreadPanel`

### Stories
- [x] Add local prop `open` to `PlayList` component for controlling conditional styling
- [x] Use state hook to control `playListState` in `ThreadPanel` component