### PR TITLE
Deploy/github-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - feat/github-pages
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Build
+      run: |
+        yarn install
+        yarn build
+      env:
+        key: 
+          REACT_APP_API_SERVER: ${{ secrets.REACT_APP_API_SERVER }}
+          REACT_APP_STADIA_MAP_API_KEY: ${{ secrets.REACT_APP_STADIA_MAP_API_KEY }}
+
+    # Runs a set of commands using the runners shell
+    - name: Deploy
+      uses: JamesIves/github-pages-deploy-action@releases/v3
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH: gh-pages
+        FOLDER: dist

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,11 +20,10 @@ jobs:
         yarn install
         yarn build
       env:
-        key: 
+        key:
           REACT_APP_API_SERVER: ${{ secrets.REACT_APP_API_SERVER }}
           REACT_APP_STADIA_MAP_API_KEY: ${{ secrets.REACT_APP_STADIA_MAP_API_KEY }}
 
-    # Runs a set of commands using the runners shell
     - name: Deploy
       uses: JamesIves/github-pages-deploy-action@releases/v3
       with:


### PR DESCRIPTION
### Descriptions
- Setup github actions for deployment to github pages
- References: [dev](https://dev.to/pierresaid/deploy-node-projects-to-github-pages-with-github-actions-4jco), [stack overflow](https://stackoverflow.com/a/59320508)

### Stories
- [x] Create `gh-pages.yml`
- [x] Retrieve `REACT_APP_STADIA_MAP_API_KEY` and `REACT_APP_API_SERVER` from `secrets`