### PR TITLE
Feat/audio recorder fix show record button logic

### DIFF
--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -34,18 +34,20 @@ const Main: React.FC<IMainProps> = (props: IMainProps) => {
         side="bottom"
         disableSwipe={props.activeThread === undefined}
       >
-        <Switch>
-          <Route path="/threads/new" children={<VoiceForm />} />
+        {props.isRecording ? (
+          <TimerBar />
+        ) : (
+          <Switch>
+            <Route path="/threads/new" component={VoiceForm} />
 
-          <Route
-            path="/threads/:id/new"
-            children={<VoiceForm thread={props.activeThread} />}
-          />
+            <Route
+              path="/threads/:id/new"
+              children={<VoiceForm thread={props.activeThread} />}
+            />
 
-          <Route path="/">
-            {props.isRecording ? <TimerBar /> : <ThreadPanel />}
-          </Route>
-        </Switch>
+            <Route path="/" component={ThreadPanel} />
+          </Switch>
+        )}
       </DrawerContainer>
     </div>
   );

--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -16,7 +16,6 @@ interface IMainProps {
   drawerState: DrawerState;
   activeThread: Thread | undefined;
   showRecordButton: boolean;
-  showPlayList: boolean;
   isRecording: boolean;
 }
 
@@ -25,7 +24,7 @@ const Main: React.FC<IMainProps> = (props: IMainProps) => {
     <div className={classes.main}>
       <HeadNav />
 
-      {(props.showRecordButton || props.showPlayList) && <RecordButton />}
+      {props.showRecordButton && <RecordButton />}
 
       <DrawerContainer side="left">
         <p>drawer contents</p>
@@ -57,7 +56,6 @@ const mapStateToProps = (state: IRootState) => {
     drawerState: state.components.drawerState,
     activeThread: state.threads.activeThread,
     showRecordButton: state.components.showRecordButton,
-    showPlayList: state.components.showPlayList,
     isRecording: state.audios.isRecording
   };
 };

--- a/src/components/RecordButton/index.tsx
+++ b/src/components/RecordButton/index.tsx
@@ -5,7 +5,10 @@ import { DrawerSide } from 'redux/components/state';
 import { useHistory } from 'react-router-dom';
 import { IRootState, ThunkResult } from 'store';
 import { setAudio, setIsRecordingState } from 'redux/audios/actions';
-import { setDrawerState } from 'redux/components/actions';
+import {
+  setDrawerState,
+  setShowRecordButtonState
+} from 'redux/components/actions';
 import { connect } from 'react-redux';
 import { AudioData, AudioRecorder } from 'utils/audioRecorder';
 import classes from './styles.module.scss';
@@ -17,6 +20,7 @@ interface IRecordButtonProps {
   setAudio: (audio: AudioData) => void;
   setIsRecordingState: (isRecording: boolean) => void;
   setDrawerState: (side: DrawerSide, open: boolean) => void;
+  setShowRecordButtonState: (showRecordButton: boolean) => void;
 }
 
 const RecordButton: React.FC<IRecordButtonProps> = (
@@ -43,6 +47,7 @@ const RecordButton: React.FC<IRecordButtonProps> = (
         props.activeThread ? `/${props.activeThread.id}` : ''
       }/new`;
       history.push(pathname);
+      props.setShowRecordButtonState(false);
     } else {
       console.log('no audio is being recorded'); // tslint:disable-line
     }
@@ -76,7 +81,9 @@ const mapDispatchToProps = (dispatch: ThunkResult) => {
     setIsRecordingState: (isRecording: boolean) =>
       dispatch(setIsRecordingState(isRecording)),
     setDrawerState: (side: DrawerSide, open: boolean) =>
-      dispatch(setDrawerState(side, open))
+      dispatch(setDrawerState(side, open)),
+    setShowRecordButtonState: (showRecordButton: boolean) =>
+      dispatch(setShowRecordButtonState(showRecordButton))
   };
 };
 

--- a/src/components/ThreadPanel/index.tsx
+++ b/src/components/ThreadPanel/index.tsx
@@ -7,7 +7,10 @@ import { FiShare } from 'react-icons/fi';
 import { Thread, User, Voice } from 'models';
 import { IRootState, ThunkResult } from 'store';
 import { toggleThreadPlaying } from 'redux/threads/actions';
-import { setShowPlayListState } from 'redux/components/actions';
+import {
+  setShowPlayListState,
+  setShowRecordButtonState
+} from 'redux/components/actions';
 import { connect } from 'react-redux';
 import { sanitizedDate } from 'utils/time';
 import classes from './styles.module.scss';
@@ -20,16 +23,19 @@ interface IThreadPanelProps {
   showPlayList: boolean;
   toggleThreadPlaying: () => void;
   setShowPlayListState: (showPlayList: boolean) => void;
+  setShowRecordButtonState: (showRecordButton: boolean) => void;
 }
 
 const ThreadPanel: React.FC<IThreadPanelProps> = (props: IThreadPanelProps) => {
   const toggleShowPlayList = () => {
     const showPlayList = !props.showPlayList;
     props.setShowPlayListState(showPlayList);
+    props.setShowRecordButtonState(showPlayList);
   };
 
   const playOrPauseThread = () => {
     props.setShowPlayListState(true);
+    props.setShowRecordButtonState(true);
     props.toggleThreadPlaying();
   };
 
@@ -118,7 +124,9 @@ const mapDispatchToProps = (dispatch: ThunkResult) => {
   return {
     toggleThreadPlaying: () => dispatch(toggleThreadPlaying()),
     setShowPlayListState: (showPlayList: boolean) =>
-      dispatch(setShowPlayListState(showPlayList))
+      dispatch(setShowPlayListState(showPlayList)),
+    setShowRecordButtonState: (showRecordButton: boolean) =>
+      dispatch(setShowRecordButtonState(showRecordButton))
   };
 };
 

--- a/src/utils/audioRecorder.ts
+++ b/src/utils/audioRecorder.ts
@@ -15,10 +15,10 @@ export const audioRecorder = () =>
       audio: true
     });
     const mediaRecorder: MediaRecorder = new MediaRecorder(stream);
-    const audioChunks: Array<Blob> = [];
+    let audioChunk: Blob | undefined;
 
     const dataAvailableHandler = (event: BlobEvent) => {
-      audioChunks.push(event.data);
+      audioChunk = event.data;
     };
 
     mediaRecorder.addEventListener(
@@ -31,7 +31,7 @@ export const audioRecorder = () =>
     const stop = () =>
       new Promise((resolve: (audioData: AudioData) => void) => {
         const stopHandler: EventListenerOrEventListenerObject = () => {
-          const audioBlob = new Blob(audioChunks);
+          const audioBlob = new Blob([audioChunk as Blob]);
           const audioUrl = URL.createObjectURL(audioBlob);
           const audio = new Audio(audioUrl);
           const play = () => audio.play();


### PR DESCRIPTION
### Descriptions
- Fix `showRecordButton` logic to hide `RecordButton` when `ThreadForm` or `VoiceForm` is shown

### Stories
- [x] Hide `RecordButton` when a route with `/new` suffix is pushed to the `router`
- [x] Show `RecordButton` when `showPlayList` is set to `true`
- [x] Remove `showPlayList` in `Main` to leave `showRecordButton` prop as the sole variable to determine whether the `RecordButton` should be rendered

### Screenshots
*new `ThreadForm`*
![image](https://user-images.githubusercontent.com/47293355/89662951-64f50880-d907-11ea-9434-4d1aae4a6495.png)

*new `VoiceForm`*
![image](https://user-images.githubusercontent.com/47293355/89663010-763e1500-d907-11ea-99e3-dcd87ac88105.png)
