### PR TITLE
Feat/audio recorder post thread and voice

### DIFF
--- a/src/assets/icons/marker.svg
+++ b/src/assets/icons/marker.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="51px" height="68px" viewBox="0 0 51 68" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Group 2</title>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="To-Edward_UI_20191205_with-title-and-number" transform="translate(-5424.000000, -3226.000000)" fill="#FFDC15" fill-rule="nonzero">
+            <g id="Music_-_Orange" transform="translate(5020.000000, 2573.000000)">
+                <g id="Group-2" transform="translate(404.060000, 653.660000)">
+                    <path d="M24.57,66.01 C24.25,66.01 23.93,65.9 23.68,65.69 C22.71,64.9 -3.41060513e-13,46.19 -3.41060513e-13,24.58 C-3.41060513e-13,11.03 11.03,4.54747351e-13 24.58,4.54747351e-13 C38.13,4.54747351e-13 49.16,11.03 49.16,24.58 C49.16,46.19 26.44,64.9 25.48,65.69 C25.21,65.9 24.9,66.01 24.57,66.01 Z M24.57,2.84 C12.58,2.84 2.82,12.6 2.82,24.59 C2.82,41.9 19.11,57.85 24.1,62.33 C24.23,62.45 24.4,62.51 24.56,62.51 C24.72,62.51 24.89,62.45 25.02,62.33 C30.01,57.85 46.3100077,41.89 46.3100077,24.59 C46.32,12.6 36.56,2.84 24.57,2.84 Z" id="Shape"></path>
+                    <circle id="Oval" cx="24.57" cy="24.59" r="14.45"></circle>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/components/AudioPlayer/index.tsx
+++ b/src/components/AudioPlayer/index.tsx
@@ -3,7 +3,7 @@ import { IconButton } from '@material-ui/core';
 import { FaPlay, FaPause } from 'react-icons/fa';
 import { IoMdClose } from 'react-icons/io';
 import RecordButton from 'components/RecordButton';
-import { Thread } from 'models';
+import { ThreadJson } from 'models';
 import { setAudio } from 'redux/audios/actions';
 import {
   setShowRecordButtonState,
@@ -16,7 +16,7 @@ import classes from './styles.module.scss';
 
 interface IAudioPlayerProps {
   audioUrl: string;
-  activeThread: Thread | undefined;
+  activeThread: ThreadJson | undefined;
   setAudio: (audio?: AudioData) => void;
   setShowRecordButtonState: (showRecordButton: boolean) => void;
   embedRecordButton: (embeddedRecordButton: boolean) => void;

--- a/src/components/DrawerContainer/index.tsx
+++ b/src/components/DrawerContainer/index.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import clsx from 'clsx';
 import { SwipeableDrawer } from '@material-ui/core';
+import { LocationJson } from 'models';
 import { IRootState, ThunkResult } from 'store';
 import { DrawerSide, DrawerState } from 'redux/components/state';
 import {
@@ -8,6 +9,7 @@ import {
   setShowRecordButtonState,
   embedRecordButton
 } from 'redux/components/actions';
+import { setGeolocation } from 'redux/geolocation/actions';
 import { connect } from 'react-redux';
 import classes from './styles.module.scss';
 
@@ -19,11 +21,19 @@ interface IDrawerContainerProps {
   setDrawerState: (side: DrawerSide, open: boolean) => void;
   setShowRecordButtonState: (showRecordButton: boolean) => void;
   embedRecordButton: (embeddedRecordButton: boolean) => void;
+  setGeolocation: (geolocation?: LocationJson) => void;
 }
 
-const DrawerContainer: React.FC<IDrawerContainerProps> = (
-  props: IDrawerContainerProps
-) => {
+const DrawerContainer: React.FC<IDrawerContainerProps> = ({
+  side,
+  drawerState,
+  disableSwipe,
+  children,
+  setDrawerState,
+  setShowRecordButtonState,
+  embedRecordButton,
+  setGeolocation
+}: IDrawerContainerProps) => {
   const toggleDrawer = (side: DrawerSide, open: boolean) => (
     event: React.KeyboardEvent | React.MouseEvent
   ) => {
@@ -35,25 +45,30 @@ const DrawerContainer: React.FC<IDrawerContainerProps> = (
     ) {
       return;
     }
-    props.setShowRecordButtonState(!open);
-    props.setDrawerState(side, open);
-    props.embedRecordButton(open); /* reset RecordButton */
+    setShowRecordButtonState(!open);
+    setDrawerState(side, open);
+    embedRecordButton(open); /* reset RecordButton */
   };
+
+  useEffect(() => {
+    if (!drawerState.bottom) {
+      setGeolocation();
+    }
+  }, [drawerState.bottom, setGeolocation]);
 
   return (
     <SwipeableDrawer
-      anchor={props.side}
-      open={props.drawerState[props.side]}
-      disableSwipeToOpen={props.disableSwipe}
-      onClose={toggleDrawer(props.side, false)}
-      onOpen={toggleDrawer(props.side, true)}
+      anchor={side}
+      open={drawerState[side]}
+      disableSwipeToOpen={disableSwipe}
+      onClose={toggleDrawer(side, false)}
+      onOpen={toggleDrawer(side, true)}
       className={clsx({
         [classes.drawer]: true,
-        [classes['drawer-horizontal']]:
-          props.side === 'left' || props.side === 'right'
+        [classes['drawer-horizontal']]: side === 'left' || side === 'right'
       })}
     >
-      {props.children}
+      {children}
     </SwipeableDrawer>
   );
 };
@@ -71,7 +86,9 @@ const mapDispatchToProps = (dispatch: ThunkResult) => {
     setShowRecordButtonState: (showRecordButton: boolean) =>
       dispatch(setShowRecordButtonState(showRecordButton)),
     embedRecordButton: (embeddedRecordButton: boolean) =>
-      dispatch(embedRecordButton(embeddedRecordButton))
+      dispatch(embedRecordButton(embeddedRecordButton)),
+    setGeolocation: (geolocation?: LocationJson) =>
+      dispatch(setGeolocation(geolocation))
   };
 };
 

--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -7,12 +7,11 @@ import ThreadPanel from 'components/ThreadPanel';
 import TimerBar from 'components/TimerBar';
 import VoiceForm from 'components/VoiceForm';
 import { ThreadJson } from 'models';
+import { REACT_APP_URL_PREFIX } from 'variables';
 import { IRootState, ThunkResult } from 'store';
 import { DrawerState } from 'redux/components/state';
 import { connect } from 'react-redux';
 import classes from './styles.module.scss';
-
-const { REACT_APP_URL_PREFIX } = process.env;
 
 interface IMainProps {
   drawerState: DrawerState;

--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -6,7 +6,7 @@ import DrawerContainer from 'components/DrawerContainer';
 import ThreadPanel from 'components/ThreadPanel';
 import TimerBar from 'components/TimerBar';
 import VoiceForm from 'components/VoiceForm';
-import { Thread } from 'models';
+import { ThreadJson } from 'models';
 import { IRootState, ThunkResult } from 'store';
 import { DrawerState } from 'redux/components/state';
 import { connect } from 'react-redux';
@@ -16,7 +16,7 @@ const { REACT_APP_URL_PREFIX } = process.env;
 
 interface IMainProps {
   drawerState: DrawerState;
-  activeThread: Thread | undefined;
+  activeThread: ThreadJson | undefined;
   showRecordButton: boolean;
   isRecording: boolean;
 }

--- a/src/components/Map/constant.ts
+++ b/src/components/Map/constant.ts
@@ -1,6 +1,5 @@
 import L from 'leaflet';
-
-const { REACT_APP_STADIA_MAP_API_KEY } = process.env;
+import { REACT_APP_STADIA_MAP_API_KEY } from 'variables';
 
 const tsimShaTsuiLatLng: [number, number] = [22.2988, 114.1722];
 

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -2,8 +2,9 @@ import React, { useEffect, useRef } from 'react';
 import { useHistory } from 'react-router';
 import L from 'leaflet';
 import { ThreadJson, LocationJson } from 'models';
-import { IRootState, ThunkResult } from 'store';
+import { REACT_APP_URL_PREFIX } from 'variables';
 import { DrawerSide } from 'redux/components/state';
+import { IRootState, ThunkResult } from 'store';
 import { setActiveThread, stopPlayingThread } from 'redux/threads/actions';
 import {
   setDrawerState,
@@ -14,8 +15,6 @@ import { loadVoices } from 'redux/voices/thunks';
 import { connect } from 'react-redux';
 import { urlTemplate, attribution, options } from './constant';
 import classes from './styles.module.scss';
-
-const { REACT_APP_URL_PREFIX } = process.env;
 
 interface IMapProps {
   threads: Array<ThreadJson>;

--- a/src/components/Map/styles.module.scss
+++ b/src/components/Map/styles.module.scss
@@ -8,7 +8,7 @@
     filter: contrast(1.4) hue-rotate(260deg) saturate(1.3) brightness(0.8);
   }
 
-  .icon {
+  .thread {
     background-color: rgba(get-color(white), 0.9);
     border-radius: 50%;
     box-shadow: inset 0px 0px 3px 3px get-color(gold), 0px 0px 5px 5px rgba(get-color(gold), 0.9);
@@ -18,6 +18,17 @@
     &:active {
       zoom: 1;
     }
+  }
+
+  .new-thread {
+    background-image: url('../../assets/icons/marker.svg');
+    background-position: center;
+    background-size: contain;
+    background-repeat: no-repeat;
+    width: 25px !important;
+    height: 35px !important;
+    transform-origin: center;
+    outline: none;
   }
 
   .popup {

--- a/src/components/PlayList/index.tsx
+++ b/src/components/PlayList/index.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import clsx from 'clsx';
 import VoiceInfo from 'components/VoiceInfo';
-import { Voice } from 'models';
+import { VoiceJson } from 'models';
 import { IRootState, ThunkResult } from 'store';
 import { connect } from 'react-redux';
 import classes from './styles.module.scss';
 
 interface IPlayListProps {
   open: boolean;
-  voices: Array<Voice>;
+  voices: Array<VoiceJson>;
 }
 
 const PlayList: React.FC<IPlayListProps> = (props: IPlayListProps) => {

--- a/src/components/RecordButton/index.tsx
+++ b/src/components/RecordButton/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
+import { useHistory, useLocation } from 'react-router';
 import clsx from 'clsx';
 import { IconButton } from '@material-ui/core';
-import { Thread } from 'models';
+import { ThreadJson, LocationJson } from 'models';
 import { DrawerSide } from 'redux/components/state';
-import { useHistory, useLocation } from 'react-router-dom';
 import { IRootState, ThunkResult } from 'store';
 import { setAudio, setIsRecordingState } from 'redux/audios/actions';
 import {
@@ -11,8 +11,10 @@ import {
   setShowRecordButtonState,
   embedRecordButton
 } from 'redux/components/actions';
+import { setGeolocation } from 'redux/geolocation/actions';
 import { connect } from 'react-redux';
 import { AudioData, AudioRecorder } from 'utils/audioRecorder';
+import { getLocationJson } from 'utils/geolocation';
 import classes from './styles.module.scss';
 
 const { REACT_APP_URL_PREFIX } = process.env;
@@ -20,7 +22,7 @@ const { REACT_APP_URL_PREFIX } = process.env;
 interface IRecordButtonProps {
   recorder: AudioRecorder | undefined;
   isRecording: boolean;
-  activeThread: Thread | undefined;
+  activeThread: ThreadJson | undefined;
   showRecordButton: boolean;
   embeddedRecordButton: boolean;
   setAudio: (audio?: AudioData) => void;
@@ -28,6 +30,7 @@ interface IRecordButtonProps {
   setDrawerState: (side: DrawerSide, open: boolean) => void;
   setShowRecordButtonState: (showRecordButton: boolean) => void;
   embedRecordButton: (embeddedRecordButton: boolean) => void;
+  setGeolocation: (geolocation?: LocationJson) => void;
 }
 
 const RecordButton: React.FC<IRecordButtonProps> = (
@@ -38,6 +41,7 @@ const RecordButton: React.FC<IRecordButtonProps> = (
 
   const startRecording = () => {
     if (props.recorder && !props.isRecording) {
+      props.setGeolocation();
       const pathname = location.pathname.replace('/new', '');
       history.push(pathname);
       props.setDrawerState('bottom', true);
@@ -61,6 +65,9 @@ const RecordButton: React.FC<IRecordButtonProps> = (
       }/new`;
       history.push(pathname);
       props.setShowRecordButtonState(false);
+
+      const geolocation = await getLocationJson();
+      props.setGeolocation(geolocation);
     } else {
       console.log('no audio is being recorded'); /* tslint:disable-line */
     }
@@ -114,7 +121,9 @@ const mapDispatchToProps = (dispatch: ThunkResult) => {
     setShowRecordButtonState: (showRecordButton: boolean) =>
       dispatch(setShowRecordButtonState(showRecordButton)),
     embedRecordButton: (embeddedRecordButton: boolean) =>
-      dispatch(embedRecordButton(embeddedRecordButton))
+      dispatch(embedRecordButton(embeddedRecordButton)),
+    setGeolocation: (geolocation?: LocationJson) =>
+      dispatch(setGeolocation(geolocation))
   };
 };
 

--- a/src/components/RecordButton/index.tsx
+++ b/src/components/RecordButton/index.tsx
@@ -3,6 +3,7 @@ import { useHistory, useLocation } from 'react-router';
 import clsx from 'clsx';
 import { IconButton } from '@material-ui/core';
 import { ThreadJson, LocationJson } from 'models';
+import { REACT_APP_URL_PREFIX } from 'variables';
 import { DrawerSide } from 'redux/components/state';
 import { IRootState, ThunkResult } from 'store';
 import { setAudio, setIsRecordingState } from 'redux/audios/actions';
@@ -16,8 +17,6 @@ import { connect } from 'react-redux';
 import { AudioData, AudioRecorder } from 'utils/audioRecorder';
 import { getLocationJson } from 'utils/geolocation';
 import classes from './styles.module.scss';
-
-const { REACT_APP_URL_PREFIX } = process.env;
 
 interface IRecordButtonProps {
   recorder: AudioRecorder | undefined;

--- a/src/components/ThreadPanel/index.tsx
+++ b/src/components/ThreadPanel/index.tsx
@@ -4,7 +4,7 @@ import { IconButton } from '@material-ui/core';
 import { FaRegStar, FaPlay, FaPause } from 'react-icons/fa';
 import { MdSkipPrevious, MdSkipNext } from 'react-icons/md';
 import { FiShare } from 'react-icons/fi';
-import { Thread, User, Voice } from 'models';
+import { ThreadJson, User, VoiceJson } from 'models';
 import { IRootState, ThunkResult } from 'store';
 import { toggleThreadPlaying } from 'redux/threads/actions';
 import {
@@ -16,9 +16,9 @@ import { sanitizedDate } from 'utils/time';
 import classes from './styles.module.scss';
 
 interface IThreadPanelProps {
-  activeThread: Thread | undefined;
+  activeThread: ThreadJson | undefined;
   users: Array<User>;
-  voices: Array<Voice>;
+  voices: Array<VoiceJson>;
   threadPlaying: boolean;
   showPlayList: boolean;
   toggleThreadPlaying: () => void;
@@ -53,7 +53,7 @@ const ThreadPanel: React.FC<IThreadPanelProps> = (props: IThreadPanelProps) => {
             <p className={classes.info}>
               {
                 props.users.find(
-                  user => user.id === props.activeThread?.user_id.split('/')[1]
+                  user => user.id === props.activeThread?.user_id!.split('/')[1]
                 )?.username
               }
               ・{sanitizedDate(props.activeThread.timestamp as any)}

--- a/src/components/VoiceForm/index.tsx
+++ b/src/components/VoiceForm/index.tsx
@@ -6,6 +6,7 @@ import AudioPlayer from 'components/AudioPlayer';
 import { RiFileAddLine } from 'react-icons/ri';
 import { FaMusic, FaCheck } from 'react-icons/fa';
 import { ThreadJson, VoiceJson, LocationJson } from 'models';
+import { REACT_APP_URL_PREFIX } from 'variables';
 import { VoiceFormData } from 'redux/components/state';
 import { IRootState, ThunkResult } from 'store';
 import { createThread } from 'redux/threads/thunks';
@@ -15,8 +16,6 @@ import { connect } from 'react-redux';
 import { AudioData } from 'utils/audioRecorder';
 import { getTimestampJson } from 'utils/time';
 import classes from './styles.module.scss';
-
-const { REACT_APP_URL_PREFIX } = process.env;
 
 interface IVoiceFormProps {
   audio: AudioData | undefined;

--- a/src/components/VoiceForm/index.tsx
+++ b/src/components/VoiceForm/index.tsx
@@ -1,23 +1,35 @@
 import React, { useState } from 'react';
+import { useHistory } from 'react-router';
 import { useForm } from 'react-hook-form';
 import { IconButton } from '@material-ui/core';
 import AudioPlayer from 'components/AudioPlayer';
 import { RiFileAddLine } from 'react-icons/ri';
 import { FaMusic, FaCheck } from 'react-icons/fa';
-import { Thread } from 'models';
+import { ThreadJson, VoiceJson, LocationJson } from 'models';
 import { VoiceFormData } from 'redux/components/state';
 import { IRootState, ThunkResult } from 'store';
+import { createThread } from 'redux/threads/thunks';
+import { createVoice } from 'redux/voices/thunks';
+import { setGeolocation } from 'redux/geolocation/actions';
 import { connect } from 'react-redux';
 import { AudioData } from 'utils/audioRecorder';
+import { getTimestampJson } from 'utils/time';
 import classes from './styles.module.scss';
+
+const { REACT_APP_URL_PREFIX } = process.env;
 
 interface IVoiceFormProps {
   audio: AudioData | undefined;
-  thread?: Thread;
+  thread?: ThreadJson;
+  geolocation: LocationJson | undefined;
+  createThread: (newThread: ThreadJson) => Promise<ThreadJson | undefined>;
+  createVoice: (newVoice: VoiceJson) => Promise<VoiceJson | undefined>;
+  setGeolocation: (geolocation?: LocationJson) => void;
 }
 
 const VoiceForm: React.FC<IVoiceFormProps> = (props: IVoiceFormProps) => {
   const { register, handleSubmit } = useForm<VoiceFormData>();
+  const history = useHistory();
 
   const [value, setValue] = useState<string>(
     props.thread ? props.thread.title : ''
@@ -26,8 +38,52 @@ const VoiceForm: React.FC<IVoiceFormProps> = (props: IVoiceFormProps) => {
   const handleInput = (event: React.ChangeEvent<HTMLInputElement>) =>
     setValue(event.target.value);
 
-  const submitVoice = (voiceFormData: VoiceFormData) => {
-    console.log({ voiceFormData }); // tslint:disable-line
+  const submitVoice = async (voiceFormData: VoiceFormData) => {
+    if (props.audio) {
+      const { threadTitle } = voiceFormData;
+
+      const timestamp = getTimestampJson();
+      const location = props.geolocation;
+
+      if (!location) return console.log('Location is not available!'); /* tslint:disable-line */
+      let threadId = '';
+      if (!props.thread) {
+        const newThread: ThreadJson = {
+          is_active: true,
+          title: threadTitle,
+          user_id: 'Z1aO565FJD1ZmaOqI9Mi', // TODO: replace hard coded user_id with logged in user.id from redux store
+          color_code: 'Y', // TODO: replace hard coded color_code with color_code state from redux store
+          bookmarked_by_users: [],
+          location,
+          timestamp
+        };
+
+        const thread = (await props.createThread(newThread)) as ThreadJson;
+        threadId = thread.id as string;
+      } else {
+        threadId = props.thread.id as string;
+      }
+
+      const newVoice: VoiceJson = {
+        is_active: true,
+        thread_id: threadId,
+        user_id: 'Z1aO565FJD1ZmaOqI9Mi', // TODO: replace hard coded user_id with logged in user.id from redux store
+        voice_url: props.audio.audioUrl,
+        liked_by_users: [],
+        location,
+        timestamp
+      };
+
+      const voice = await props.createVoice(newVoice);
+
+      const { thread_id } = voice as VoiceJson;
+
+      props.setGeolocation();
+      const pathname = `${REACT_APP_URL_PREFIX}/${thread_id}`;
+      history.push(pathname);
+    } else {
+      console.log('No voice has been recorded yet!'); /* tslint:disable-line */
+    }
   };
 
   return (
@@ -106,12 +162,18 @@ const VoiceForm: React.FC<IVoiceFormProps> = (props: IVoiceFormProps) => {
 
 const mapStateToProps = (state: IRootState) => {
   return {
-    audio: state.audios.audio
+    audio: state.audios.audio,
+    geolocation: state.geolocation.geolocation
   };
 };
 
 const mapDispatchToProps = (dispatch: ThunkResult) => {
-  return {};
+  return {
+    createThread: (newThread: ThreadJson) => dispatch(createThread(newThread)),
+    createVoice: (newVoice: VoiceJson) => dispatch(createVoice(newVoice)),
+    setGeolocation: (geolocation?: LocationJson) =>
+      dispatch(setGeolocation(geolocation))
+  };
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(VoiceForm);

--- a/src/components/VoiceInfo/index.tsx
+++ b/src/components/VoiceInfo/index.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { IconButton } from '@material-ui/core';
 import { FaUserPlus, FaRegHeart } from 'react-icons/fa';
-import { Voice, User } from 'models';
+import { VoiceJson, User } from 'models';
 import { IRootState, ThunkResult } from 'store';
 import { connect } from 'react-redux';
 import { sanitizedDate } from 'utils/time';
 import classes from './styles.module.scss';
 
 interface IVoiceInfoProps {
-  voice: Voice;
+  voice: VoiceJson;
   users: Array<User>;
 }
 

--- a/src/models/index.tsx
+++ b/src/models/index.tsx
@@ -1,26 +1,36 @@
 import { firestore } from 'firebase';
 
 /* api */
-export interface Thread {
+export interface LocationJson {
+  _latitude: number;
+  _longitude: number;
+}
+
+export interface TimestampJson {
+  _seconds: number;
+  _nanoseconds: number;
+}
+
+export interface ThreadJson {
   id?: string;
   is_active: boolean;
   title: string;
   user_id: string;
   color_code?: 'Y' | 'B';
   bookmarked_by_users: Array<string>;
-  location: firestore.GeoPoint;
-  timestamp: firestore.Timestamp;
+  location: LocationJson;
+  timestamp: TimestampJson;
 }
 
-export interface Voice {
+export interface VoiceJson {
   id?: string;
   is_active: boolean;
   thread_id: string;
   user_id: string;
   voice_url: string;
   liked_by_users: Array<string>;
-  location: firestore.GeoPoint;
-  timestamp: firestore.Timestamp;
+  location: LocationJson;
+  timestamp: TimestampJson;
 }
 
 export interface User {

--- a/src/redux/geolocation/actions.ts
+++ b/src/redux/geolocation/actions.ts
@@ -1,0 +1,12 @@
+import { LocationJson } from 'models';
+
+export function setGeolocation(geolocation?: LocationJson) {
+  return {
+    type: 'SET_GEOLOCATION' as 'SET_GEOLOCATION',
+    geolocation
+  };
+}
+
+type GeolocationActionCreators = typeof setGeolocation;
+
+export type IGeolocationAction = ReturnType<GeolocationActionCreators>;

--- a/src/redux/geolocation/reducer.ts
+++ b/src/redux/geolocation/reducer.ts
@@ -1,0 +1,22 @@
+import { IGeolocationState } from './state';
+import { IGeolocationAction } from './actions';
+
+const initialState: IGeolocationState = {
+  geolocation: undefined
+};
+
+export const geolocationReducer = (
+  state: IGeolocationState = initialState,
+  action: IGeolocationAction
+): IGeolocationState => {
+  switch (action.type) {
+    case 'SET_GEOLOCATION':
+      const { geolocation } = action;
+      return {
+        ...state,
+        geolocation
+      };
+    default:
+      return state;
+  }
+};

--- a/src/redux/geolocation/state.ts
+++ b/src/redux/geolocation/state.ts
@@ -1,0 +1,5 @@
+import { LocationJson } from 'models';
+
+export interface IGeolocationState {
+  geolocation: LocationJson | undefined;
+}

--- a/src/redux/threads/actions.ts
+++ b/src/redux/threads/actions.ts
@@ -1,13 +1,20 @@
-import { Thread } from 'models';
+import { ThreadJson } from 'models';
 
-export function loadThreadsSuccess(threads: Array<Thread>) {
+export function loadThreadsSuccess(threads: Array<ThreadJson>) {
   return {
     type: 'LOAD_THREADS' as 'LOAD_THREADS',
     threads
   };
 }
 
-export function setActiveThread(activeThread?: Thread) {
+export function createThreadSuccess(newThread: ThreadJson) {
+  return {
+    type: 'CREATE_THREAD' as 'CREATE_THREAD',
+    newThread
+  };
+}
+
+export function setActiveThread(activeThread?: ThreadJson) {
   return {
     type: 'SET_ACTIVE_THREAD' as 'SET_ACTIVE_THREAD',
     activeThread
@@ -33,10 +40,11 @@ export function failed(type: FAILED, msg: string) {
   };
 }
 
-type FAILED = 'LOAD_THREADS_FAILED';
+type FAILED = 'LOAD_THREADS_FAILED' | 'CREATE_THREAD_FAILED';
 
 type ThreadsActionCreators =
   | typeof loadThreadsSuccess
+  | typeof createThreadSuccess
   | typeof setActiveThread
   | typeof toggleThreadPlaying
   | typeof stopPlayingThread

--- a/src/redux/threads/reducer.ts
+++ b/src/redux/threads/reducer.ts
@@ -1,5 +1,6 @@
 import { IThreadsState } from './state';
 import { IThreadsAction } from './actions';
+import { ThreadJson } from 'models';
 
 const initialState: IThreadsState = {
   threads: [],
@@ -12,29 +13,41 @@ export const threadsReducer = (
   action: IThreadsAction
 ): IThreadsState => {
   switch (action.type) {
-    case 'LOAD_THREADS':
+    case 'LOAD_THREADS': {
       const { threads } = action;
       return {
         ...state,
         threads
       };
-    case 'SET_ACTIVE_THREAD':
+    }
+    case 'CREATE_THREAD': {
+      const { newThread } = action;
+      const threads: Array<ThreadJson> = state.threads.concat(newThread);
+      return {
+        ...state,
+        threads
+      };
+    }
+    case 'SET_ACTIVE_THREAD': {
       const { activeThread } = action;
       return {
         ...state,
         activeThread
       };
-    case 'TOGGLE_THREAD_PLAYING':
+    }
+    case 'TOGGLE_THREAD_PLAYING': {
       const threadPlaying = !state.threadPlaying;
       return {
         ...state,
         threadPlaying
       };
-    case 'STOP_PLAYING_THREAD':
+    }
+    case 'STOP_PLAYING_THREAD': {
       return {
         ...state,
         threadPlaying: false
       };
+    }
     default:
       return state;
   }

--- a/src/redux/threads/state.ts
+++ b/src/redux/threads/state.ts
@@ -1,7 +1,7 @@
-import { Thread } from 'models';
+import { ThreadJson } from 'models';
 
 export interface IThreadsState {
-  threads: Array<Thread>;
-  activeThread: Thread | undefined;
+  threads: Array<ThreadJson>;
+  activeThread: ThreadJson | undefined;
   threadPlaying: boolean;
 }

--- a/src/redux/threads/thunks.ts
+++ b/src/redux/threads/thunks.ts
@@ -1,5 +1,11 @@
 import { Dispatch } from 'redux';
-import { IThreadsAction, loadThreadsSuccess, failed } from './actions';
+import { ThreadJson } from 'models';
+import {
+  IThreadsAction,
+  loadThreadsSuccess,
+  createThreadSuccess,
+  failed
+} from './actions';
 
 const { REACT_APP_API_SERVER } = process.env;
 
@@ -14,6 +20,26 @@ export function loadThreads() {
       dispatch(loadThreadsSuccess(data));
     } else {
       dispatch(failed('LOAD_THREADS_FAILED', data));
+    }
+  };
+}
+
+export function createThread(newThread: ThreadJson) {
+  return async (dispatch: Dispatch<IThreadsAction>) => {
+    const res = await fetch(`${REACT_APP_API_SERVER}/threads`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8'
+      },
+      body: JSON.stringify(newThread)
+    });
+    const { isSuccess, data } = await res.json();
+
+    if (isSuccess) {
+      dispatch(createThreadSuccess(data));
+      return data as ThreadJson;
+    } else {
+      dispatch(failed('CREATE_THREAD_FAILED', data));
     }
   };
 }

--- a/src/redux/threads/thunks.ts
+++ b/src/redux/threads/thunks.ts
@@ -1,13 +1,12 @@
 import { Dispatch } from 'redux';
 import { ThreadJson } from 'models';
+import { REACT_APP_API_SERVER } from 'variables';
 import {
   IThreadsAction,
   loadThreadsSuccess,
   createThreadSuccess,
   failed
 } from './actions';
-
-const { REACT_APP_API_SERVER } = process.env;
 
 export function loadThreads() {
   return async (dispatch: Dispatch<IThreadsAction>) => {

--- a/src/redux/users/thunks.ts
+++ b/src/redux/users/thunks.ts
@@ -1,7 +1,6 @@
 import { Dispatch } from 'redux';
+import { REACT_APP_API_SERVER } from 'variables';
 import { IUsersAction, loadUsersSuccess, failed } from './actions';
-
-const { REACT_APP_API_SERVER } = process.env;
 
 export function loadUsers() {
   return async (dispatch: Dispatch<IUsersAction>) => {

--- a/src/redux/voices/actions.ts
+++ b/src/redux/voices/actions.ts
@@ -1,6 +1,6 @@
-import { Voice } from 'models';
+import { VoiceJson } from 'models';
 
-export function loadVoicesSuccess(voices: Array<Voice>) {
+export function loadVoicesSuccess(voices: Array<VoiceJson>) {
   return {
     type: 'LOAD_VOICES' as 'LOAD_VOICES',
     voices
@@ -14,7 +14,7 @@ export function failed(type: FAILED, msg: string) {
   };
 }
 
-type FAILED = 'LOAD_VOICES_FAILED';
+type FAILED = 'LOAD_VOICES_FAILED' | 'CREATE_VOICE_FAILED';
 
 type VoicesActionCreators = typeof loadVoicesSuccess | typeof failed;
 

--- a/src/redux/voices/state.ts
+++ b/src/redux/voices/state.ts
@@ -1,5 +1,5 @@
-import { Voice } from 'models';
+import { VoiceJson } from 'models';
 
 export interface IVoicesState {
-  voices: Array<Voice>;
+  voices: Array<VoiceJson>;
 }

--- a/src/redux/voices/thunks.ts
+++ b/src/redux/voices/thunks.ts
@@ -1,8 +1,7 @@
 import { Dispatch } from 'redux';
-import { IVoicesAction, loadVoicesSuccess, failed } from './actions';
 import { VoiceJson } from 'models';
-
-const { REACT_APP_API_SERVER } = process.env;
+import { REACT_APP_API_SERVER } from 'variables';
+import { IVoicesAction, loadVoicesSuccess, failed } from './actions';
 
 export function loadVoices(threadId: string) {
   return async (dispatch: Dispatch<IVoicesAction>) => {

--- a/src/redux/voices/thunks.ts
+++ b/src/redux/voices/thunks.ts
@@ -1,5 +1,6 @@
 import { Dispatch } from 'redux';
 import { IVoicesAction, loadVoicesSuccess, failed } from './actions';
+import { VoiceJson } from 'models';
 
 const { REACT_APP_API_SERVER } = process.env;
 
@@ -15,6 +16,25 @@ export function loadVoices(threadId: string) {
       dispatch(loadVoicesSuccess(data));
     } else {
       dispatch(failed('LOAD_VOICES_FAILED', data));
+    }
+  };
+}
+
+export function createVoice(newVoice: VoiceJson) {
+  return async (dispatch: Dispatch<IVoicesAction>) => {
+    const res = await fetch(`${REACT_APP_API_SERVER}/voices`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8'
+      },
+      body: JSON.stringify(newVoice)
+    });
+    const { isSuccess, data } = await res.json();
+
+    if (isSuccess) {
+      return data as VoiceJson;
+    } else {
+      dispatch(failed('CREATE_VOICE_FAILED', data));
     }
   };
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -17,18 +17,21 @@ import { IThreadsState } from 'redux/threads/state';
 import { IVoicesState } from 'redux/voices/state';
 import { IUsersState } from 'redux/users/state';
 import { IAudiosState } from 'redux/audios/state';
+import { IGeolocationState } from 'redux/geolocation/state';
 import { IChannelsState } from 'redux/channels/state';
 import { IComponentsState } from 'redux/components/state';
 import { IThreadsAction } from 'redux/threads/actions';
 import { IVoicesAction } from 'redux/voices/actions';
 import { IUsersAction } from 'redux/users/actions';
 import { IAudiosAction } from 'redux/audios/actions';
+import { IGeolocationAction } from 'redux/geolocation/actions';
 import { IChannelsActions } from 'redux/channels/actions';
 import { IComponentsAction } from 'redux/components/actions';
 import { threadsReducer } from 'redux/threads/reducer';
 import { voicesReducer } from 'redux/voices/reducer';
 import { usersReducer } from 'redux/users/reducer';
 import { audiosReducer } from 'redux/audios/reducer';
+import { geolocationReducer } from 'redux/geolocation/reducer';
 import { channelsReducer } from 'redux/channels/reducer';
 import { componentsReducer } from 'redux/components/reducer';
 
@@ -48,6 +51,7 @@ export interface IRootState {
   voices: IVoicesState;
   users: IUsersState;
   audios: IAudiosState;
+  geolocation: IGeolocationState;
   channels: IChannelsState;
   components: IComponentsState;
   router: RouterState;
@@ -58,6 +62,7 @@ type IRootAction =
   | IVoicesAction
   | IUsersAction
   | IAudiosAction
+  | IGeolocationAction
   | IChannelsActions
   | IComponentsAction;
 
@@ -66,6 +71,7 @@ const rootReducer = combineReducers<IRootState>({
   voices: voicesReducer,
   users: usersReducer,
   audios: audiosReducer,
+  geolocation: geolocationReducer,
   channels: channelsReducer,
   components: componentsReducer,
   router: connectRouter(history)

--- a/src/utils/geolocation.ts
+++ b/src/utils/geolocation.ts
@@ -1,0 +1,31 @@
+function getGeolocation() {
+  const { geolocation } = window.navigator;
+  if (geolocation) {
+    const getCurrentPositionPromise = () => {
+      return new Promise(
+        (resolve: PositionCallback, reject: PositionErrorCallback) => {
+          geolocation.getCurrentPosition(resolve, reject);
+        }
+      );
+    };
+    return getCurrentPositionPromise();
+  } else {
+    console.log('Geolocation is not supported!'); /* tslint:disable-line */
+  }
+}
+
+function positionToLocationJson(position: Position) {
+  const {
+    coords: { latitude, longitude }
+  } = position;
+  const location = {
+    _latitude: latitude,
+    _longitude: longitude
+  };
+  return location;
+}
+
+export async function getLocationJson() {
+  const position = await getGeolocation();
+  return position ? positionToLocationJson(position) : undefined;
+}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -9,3 +9,11 @@ export function sanitizedDate(timestampObj: {
   const timestamp = new firestore.Timestamp(_seconds, _nanoseconds);
   return moment(timestamp.toDate()).fromNow();
 }
+
+export function getTimestampJson() {
+  const milliseconds = Date.now();
+  const _seconds = Math.floor(milliseconds / 1000);
+  const _nanoseconds = (milliseconds - _seconds * 1000) * 1000000;
+  const timestamp = { _seconds, _nanoseconds };
+  return timestamp;
+}

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -1,0 +1,5 @@
+export const {
+  REACT_APP_API_SERVER,
+  REACT_APP_STADIA_MAP_API_KEY,
+  REACT_APP_URL_PREFIX
+} = process.env;


### PR DESCRIPTION
### Descriptions
- Convert `VoiceForm` data and recorded audio into `thread` and `voice` and post them to the BE

### Stories
- [x] Create `LocationJson`,  `TimestampJson` in model
- [x] Replace `Thread` and `Voice` with `ThreadJson` and `VoiceJson` in model
- [x] Update `Thread` and `Voice` to `ThreadJson` and `VoiceJson` models throughout the repository
- [x] Create `geolocation` utils with `getGeolocation`, `positionToLocationJason` and `getLocationJson` methods
- [x] Create `IGeolocationState`, `IGeolocationAction` and `geolocationReducer` and import them into redux store
- [x] Call `setGeolocation` in both `startRecording` and `stopRecording` methods in `RecordButton`
- [x] Use `geolocation` from the redux store to add new thread marker on the `Map`
- [x] Call `setGeolocation` to remove new thread marker on `Map` when bottom drawer is closed in `DrawerContainer`
- [x] Create `getTimestampJson` method in `time` utils
- [x] Add `createThread` and `createThreadSuccess` methods in threads actions and Add `CREATE_THREAD` case in `threadsReducer`
- [x] Add `createVoice` method in voices thunk
- [x] Set up `submitVoice` method in `VoiceForm` to call `createThread` and `createVoice`
- [x] Centralise `env` variable exports in `variables` file