### PR TITLE
Feat/audio recorder fix thread route view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ const App: React.FC<IAppProps> = (props: IAppProps) => {
   return (
     <div className={classes.app}>
       <Map />
+
       <Main />
     </div>
   );

--- a/src/components/AudioPlayer/index.tsx
+++ b/src/components/AudioPlayer/index.tsx
@@ -3,7 +3,6 @@ import { IconButton } from '@material-ui/core';
 import { FaPlay, FaPause } from 'react-icons/fa';
 import { IoMdClose } from 'react-icons/io';
 import RecordButton from 'components/RecordButton';
-import { ThreadJson } from 'models';
 import { setAudio } from 'redux/audios/actions';
 import {
   setShowRecordButtonState,
@@ -16,7 +15,6 @@ import classes from './styles.module.scss';
 
 interface IAudioPlayerProps {
   audioUrl: string;
-  activeThread: ThreadJson | undefined;
   setAudio: (audio?: AudioData) => void;
   setShowRecordButtonState: (showRecordButton: boolean) => void;
   embedRecordButton: (embeddedRecordButton: boolean) => void;
@@ -77,9 +75,7 @@ const AudioPlayer: React.FC<IAudioPlayerProps> = (props: IAudioPlayerProps) => {
 };
 
 const mapStateToProps = (state: IRootState) => {
-  return {
-    activeThread: state.threads.activeThread
-  };
+  return {};
 };
 
 const mapDispatchToProps = (dispatch: ThunkResult) => {

--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -15,7 +15,7 @@ import classes from './styles.module.scss';
 
 interface IMainProps {
   drawerState: DrawerState;
-  activeThread: ThreadJson | undefined;
+  activeThread: ThreadJson | null;
   showRecordButton: boolean;
   isRecording: boolean;
 }
@@ -31,10 +31,7 @@ const Main: React.FC<IMainProps> = (props: IMainProps) => {
         <p>drawer contents</p>
       </DrawerContainer>
 
-      <DrawerContainer
-        side="bottom"
-        disableSwipe={props.activeThread === undefined}
-      >
+      <DrawerContainer side="bottom" disableSwipe={props.activeThread === null}>
         {props.isRecording ? (
           <TimerBar />
         ) : (
@@ -45,7 +42,7 @@ const Main: React.FC<IMainProps> = (props: IMainProps) => {
             />
 
             <Route
-              path={`${REACT_APP_URL_PREFIX}/threads/:id/new`}
+              path={`${REACT_APP_URL_PREFIX}/threads/:threadId/new`}
               children={<VoiceForm thread={props.activeThread} />}
             />
 

--- a/src/components/RecordButton/index.tsx
+++ b/src/components/RecordButton/index.tsx
@@ -21,7 +21,7 @@ import classes from './styles.module.scss';
 interface IRecordButtonProps {
   recorder: AudioRecorder | undefined;
   isRecording: boolean;
-  activeThread: ThreadJson | undefined;
+  activeThread: ThreadJson | null;
   showRecordButton: boolean;
   embeddedRecordButton: boolean;
   setAudio: (audio?: AudioData) => void;

--- a/src/components/ThreadPanel/index.tsx
+++ b/src/components/ThreadPanel/index.tsx
@@ -16,7 +16,7 @@ import { sanitizedDate } from 'utils/time';
 import classes from './styles.module.scss';
 
 interface IThreadPanelProps {
-  activeThread: ThreadJson | undefined;
+  activeThread: ThreadJson | null;
   users: Array<User>;
   voices: Array<VoiceJson>;
   threadPlaying: boolean;

--- a/src/components/VoiceForm/index.tsx
+++ b/src/components/VoiceForm/index.tsx
@@ -19,7 +19,7 @@ import classes from './styles.module.scss';
 
 interface IVoiceFormProps {
   audio: AudioData | undefined;
-  thread?: ThreadJson;
+  thread: ThreadJson | null;
   geolocation: LocationJson | undefined;
   createThread: (newThread: ThreadJson) => Promise<ThreadJson | undefined>;
   createVoice: (newVoice: VoiceJson) => Promise<VoiceJson | undefined>;

--- a/src/components/VoiceForm/index.tsx
+++ b/src/components/VoiceForm/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router';
 import { useForm } from 'react-hook-form';
 import { IconButton } from '@material-ui/core';
@@ -28,6 +28,7 @@ interface IVoiceFormProps {
 
 const VoiceForm: React.FC<IVoiceFormProps> = (props: IVoiceFormProps) => {
   const { register, handleSubmit } = useForm<VoiceFormData>();
+  const inputRef: React.MutableRefObject<HTMLInputElement | null> = useRef(null);
   const history = useHistory();
 
   const [value, setValue] = useState<string>(
@@ -85,6 +86,13 @@ const VoiceForm: React.FC<IVoiceFormProps> = (props: IVoiceFormProps) => {
     }
   };
 
+  /* set focus on thread title input on render */
+  useEffect(() => {
+    if (inputRef.current && !props.thread) {
+      inputRef.current.focus();
+    }
+  }, [props.thread]);
+
   return (
     <div className={classes['voice-form']}>
       <div className={classes.container}>
@@ -122,7 +130,10 @@ const VoiceForm: React.FC<IVoiceFormProps> = (props: IVoiceFormProps) => {
               <input
                 className={classes.input}
                 name="threadTitle"
-                ref={register({ required: true })}
+                ref={e => {
+                  register(e, { required: true });
+                  inputRef.current = e;
+                }}
                 type="text"
                 value={value}
                 onChange={handleInput}

--- a/src/redux/threads/actions.ts
+++ b/src/redux/threads/actions.ts
@@ -14,7 +14,7 @@ export function createThreadSuccess(newThread: ThreadJson) {
   };
 }
 
-export function setActiveThread(activeThread?: ThreadJson) {
+export function setActiveThread(activeThread: ThreadJson | null) {
   return {
     type: 'SET_ACTIVE_THREAD' as 'SET_ACTIVE_THREAD',
     activeThread

--- a/src/redux/threads/reducer.ts
+++ b/src/redux/threads/reducer.ts
@@ -4,7 +4,7 @@ import { ThreadJson } from 'models';
 
 const initialState: IThreadsState = {
   threads: [],
-  activeThread: undefined,
+  activeThread: null,
   threadPlaying: false
 };
 

--- a/src/redux/threads/state.ts
+++ b/src/redux/threads/state.ts
@@ -2,6 +2,6 @@ import { ThreadJson } from 'models';
 
 export interface IThreadsState {
   threads: Array<ThreadJson>;
-  activeThread: ThreadJson | undefined;
+  activeThread: ThreadJson | null;
   threadPlaying: boolean;
 }


### PR DESCRIPTION
### Descriptions
- Fix route view for `/threads/:threadId`

### Stories
- [x] Refactor `activeThread` state type to `ThreadJson | null` in `IThreadsState`
- [x] Update `activeThread` type throughout the repository
- [x] Add `useState` hook to set and get `markers` and `useRouteMatch` hook to check if `threadId` param exists in the route to trigger `setActiveThread` in `Map`
- [x] Remove unused `activeThread` state from `AudioPlayer`
- [x] Set focus on thread title `input` on rendering `VoiceForm` when `props.thread` is `null`