### PR TITLE
Feat/audio recorder audio storage flow

### DIFF
--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -38,7 +38,7 @@ const Main: React.FC<IMainProps> = (props: IMainProps) => {
           <Switch>
             <Route
               path={`${REACT_APP_URL_PREFIX}/threads/new`}
-              component={VoiceForm}
+              children={<VoiceForm thread={props.activeThread} />}
             />
 
             <Route

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -154,9 +154,9 @@ const Map: React.FC<IMapProps> = ({
     }
   }, [geolocation]);
 
-  /* monitor route to check if it matches /threads/:threadId */
+  /* monitor route to check if it matches /threads/:threadId or /threads/:threadId/new */
   useEffect(() => {
-    if (match && match.isExact) {
+    if (match) {
       const { threadId } = match.params as ThreadRouteParam;
       const thread = threads.find(thread => thread.id === threadId);
       stopPlayingThread();

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -162,17 +162,18 @@ const Map: React.FC<IMapProps> = ({
       stopPlayingThread();
       if (thread) {
         setActiveThread(thread);
+        loadVoices(thread.id as string);
       } else {
         setActiveThread(null);
       }
     } else {
       setActiveThread(null);
     }
-  }, [match, threads, stopPlayingThread, setActiveThread]);
+  }, [match, threads, stopPlayingThread, setActiveThread, loadVoices]);
 
+  /* open popup on activeThread changed */
   useEffect(() => {
     if (activeThread) {
-      loadVoices(activeThread.id as string);
       markerRef.current = markers[activeThread.id as string];
 
       const isPopupOpen = markerRef.current.isPopupOpen();
@@ -180,7 +181,7 @@ const Map: React.FC<IMapProps> = ({
         markerRef.current.openPopup();
       }
     }
-  }, [activeThread, markers, loadVoices]);
+  }, [activeThread, markers]);
 
   return <div id="map" className={classes.map} />;
 };

--- a/src/components/VoiceInfo/index.tsx
+++ b/src/components/VoiceInfo/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import { IconButton } from '@material-ui/core';
 import { FaUserPlus, FaRegHeart } from 'react-icons/fa';
 import { VoiceJson, User } from 'models';
@@ -13,6 +13,21 @@ interface IVoiceInfoProps {
 }
 
 const VoiceInfo: React.FC<IVoiceInfoProps> = (props: IVoiceInfoProps) => {
+  const [isPlaying, setIsPlayingState] = useState<boolean>(false);
+
+  const audioElement = document.createElement('audio');
+  audioElement.src = props.voice.voice_url;
+  const audioRef = useRef(audioElement);
+
+  const playOrPauseAudio = () => {
+    if (isPlaying) {
+      audioRef.current.pause();
+    } else {
+      audioRef.current.play();
+    }
+    setIsPlayingState(prevIsPlaying => !prevIsPlaying);
+  };
+
   return (
     <div className={classes['voice-info']}>
       <IconButton className={classes.profile} aria-label="profile">
@@ -33,7 +48,7 @@ const VoiceInfo: React.FC<IVoiceInfoProps> = (props: IVoiceInfoProps) => {
           {sanitizedDate(props.voice.timestamp as any)}
         </p>
 
-        <h3 className={classes.user}>
+        <h3 className={classes.user} onClick={playOrPauseAudio}>
           {
             props.users.find(
               user => user.id === props.voice.user_id.split('/')[1]

--- a/src/components/VoiceInfo/styles.module.scss
+++ b/src/components/VoiceInfo/styles.module.scss
@@ -49,6 +49,7 @@
       @include font-size-large;
       margin: 0;
       text-align: center;
+      cursor: pointer;
     }
   }
 }

--- a/src/redux/threads/thunks.ts
+++ b/src/redux/threads/thunks.ts
@@ -27,9 +27,7 @@ export function createThread(newThread: ThreadJson) {
   return async (dispatch: Dispatch<IThreadsAction>) => {
     const res = await fetch(`${REACT_APP_API_SERVER}/threads`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json; charset=utf-8'
-      },
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
       body: JSON.stringify(newThread)
     });
     const { isSuccess, data } = await res.json();

--- a/src/redux/voices/thunks.ts
+++ b/src/redux/voices/thunks.ts
@@ -19,14 +19,16 @@ export function loadVoices(threadId: string) {
   };
 }
 
-export function createVoice(newVoice: VoiceJson) {
+export function createVoice(newVoice: VoiceJson, audioBlob: Blob) {
+  const voiceString = JSON.stringify(newVoice);
+  const formData = new FormData();
+  formData.append('voice_string', voiceString);
+  formData.append('audio_blob', audioBlob);
+
   return async (dispatch: Dispatch<IVoicesAction>) => {
     const res = await fetch(`${REACT_APP_API_SERVER}/voices`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json; charset=utf-8'
-      },
-      body: JSON.stringify(newVoice)
+      body: formData
     });
     const { isSuccess, data } = await res.json();
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -12,7 +12,6 @@ import {
   routerMiddleware
 } from 'connected-react-router';
 import thunk, { ThunkDispatch } from 'redux-thunk';
-import logger from 'redux-logger';
 import { IThreadsState } from 'redux/threads/state';
 import { IVoicesState } from 'redux/voices/state';
 import { IUsersState } from 'redux/users/state';
@@ -82,7 +81,6 @@ export type ThunkResult = ThunkDispatch<IRootState, null, IRootAction>;
 const store: Store<IRootState, IRootAction> = createStore(
   rootReducer,
   composeEnhancers(
-    applyMiddleware(logger),
     applyMiddleware(thunk),
     applyMiddleware(routerMiddleware(history))
   )


### PR DESCRIPTION
### Descriptions
- Set up audio storage flow in `createVoice` thunk action and make audio playable on clicking the user name in `VoiceInfo`

### Stories
- [x] Refactor `createVoice` thunk action to use `formData` to store the `audioBlob` and `newVoice` as `string` for `POST /voices` request to the backend
- [x] Use updated `createVoice` method in `VoiceForm` and dispatch `loadVoices` after pushing new path to route `history`
- [x] Fix `useRouteMatch` hook logic in `Map` by removing `match.isExact`
- [x] Create `isPlaying` state with `useState` hook in `VoiceInfo` and `playOrPauseAudio` method to play the audio linked to the `voice` data
- [x] Unify `Route` components in `Main` to set `VoiceForm` with `thread` prop being `activeThread` as `children`
- [x] Remove `redux-logger` from `composeEnhancers` in the `store` to make console cleaner
- [x] Move `loadVoice` from `activeThread` effect hook to `match` effect hook in `Map`