### PR TITLE
Fix/change record gesture to double click

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import classes from './App.module.scss';
 interface IAppProps {
   loadThreads: () => void;
   loadUsers: () => void;
-  setRecorder: (recorder?: AudioRecorder) => void;
+  setRecorder: (recorder: AudioRecorder | null) => void;
 }
 
 const App: React.FC<IAppProps> = (props: IAppProps) => {
@@ -43,7 +43,8 @@ const mapDispatchToProps = (dispatch: ThunkResult) => {
   return {
     loadThreads: () => dispatch(loadThreads()),
     loadUsers: () => dispatch(loadUsers()),
-    setRecorder: (recorder?: AudioRecorder) => dispatch(setRecorder(recorder))
+    setRecorder: (recorder: AudioRecorder | null) =>
+      dispatch(setRecorder(recorder))
   };
 };
 

--- a/src/components/AudioPlayer/index.tsx
+++ b/src/components/AudioPlayer/index.tsx
@@ -15,7 +15,7 @@ import classes from './styles.module.scss';
 
 interface IAudioPlayerProps {
   audioUrl: string;
-  setAudio: (audio?: AudioData) => void;
+  setAudio: (audio: AudioData | null) => void;
   setShowRecordButtonState: (showRecordButton: boolean) => void;
   embedRecordButton: (embeddedRecordButton: boolean) => void;
 }
@@ -39,7 +39,7 @@ const AudioPlayer: React.FC<IAudioPlayerProps> = (props: IAudioPlayerProps) => {
   };
 
   const removeAudio = () => {
-    props.setAudio();
+    props.setAudio(null);
     props.embedRecordButton(true);
     props.setShowRecordButtonState(true);
   };
@@ -80,7 +80,7 @@ const mapStateToProps = (state: IRootState) => {
 
 const mapDispatchToProps = (dispatch: ThunkResult) => {
   return {
-    setAudio: (audio?: AudioData) => dispatch(setAudio(audio)),
+    setAudio: (audio: AudioData | null) => dispatch(setAudio(audio)),
     setShowRecordButtonState: (showRecordButton: boolean) =>
       dispatch(setShowRecordButtonState(showRecordButton)),
     embedRecordButton: (embeddedRecordButton: boolean) =>

--- a/src/components/DrawerContainer/index.tsx
+++ b/src/components/DrawerContainer/index.tsx
@@ -21,7 +21,7 @@ interface IDrawerContainerProps {
   setDrawerState: (side: DrawerSide, open: boolean) => void;
   setShowRecordButtonState: (showRecordButton: boolean) => void;
   embedRecordButton: (embeddedRecordButton: boolean) => void;
-  setGeolocation: (geolocation?: LocationJson) => void;
+  setGeolocation: (geolocation: LocationJson | null) => void;
 }
 
 const DrawerContainer: React.FC<IDrawerContainerProps> = ({
@@ -52,7 +52,7 @@ const DrawerContainer: React.FC<IDrawerContainerProps> = ({
 
   useEffect(() => {
     if (!drawerState.bottom) {
-      setGeolocation();
+      setGeolocation(null);
     }
   }, [drawerState.bottom, setGeolocation]);
 
@@ -87,7 +87,7 @@ const mapDispatchToProps = (dispatch: ThunkResult) => {
       dispatch(setShowRecordButtonState(showRecordButton)),
     embedRecordButton: (embeddedRecordButton: boolean) =>
       dispatch(embedRecordButton(embeddedRecordButton)),
-    setGeolocation: (geolocation?: LocationJson) =>
+    setGeolocation: (geolocation: LocationJson | null) =>
       dispatch(setGeolocation(geolocation))
   };
 };

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -93,17 +93,14 @@ const Map: React.FC<IMapProps> = ({
         pane: 'shadowPane' /* avoid masking other markers */
       });
 
-      const markerOnMousedownHandler = (event: L.LeafletEvent) => {
-        markerRef.current = event.target as L.Marker;
-        const pathname = `${REACT_APP_URL_PREFIX}/threads/${thread.id}`;
-        history.push(pathname);
-      };
-
       const popupOpenHandler = () => {
         (mapRef.current as L.Map).flyTo(position);
         setShowPlayListState(false);
         setShowRecordButtonState(false);
         setDrawerState('bottom', true);
+
+        const pathname = `${REACT_APP_URL_PREFIX}/threads/${thread.id}`;
+        history.push(pathname);
       };
 
       const popupCloseHandler = () => {
@@ -116,7 +113,6 @@ const Map: React.FC<IMapProps> = ({
 
       const marker = L.marker(position, { icon })
         .bindPopup(popup)
-        .on('mousedown', markerOnMousedownHandler)
         .on('popupopen', popupOpenHandler)
         .on('popupclose', popupCloseHandler)
         .addTo(layerRef.current as L.LayerGroup);

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -19,7 +19,7 @@ import classes from './styles.module.scss';
 interface IMapProps {
   activeThread: ThreadJson | null;
   threads: Array<ThreadJson>;
-  geolocation: LocationJson | undefined;
+  geolocation: LocationJson | null;
   setActiveThread: (thread: ThreadJson | null) => void;
   loadVoices: (threadId: string) => void;
   stopPlayingThread: () => void;

--- a/src/components/RecordButton/index.tsx
+++ b/src/components/RecordButton/index.tsx
@@ -19,7 +19,7 @@ import { getLocationJson } from 'utils/geolocation';
 import classes from './styles.module.scss';
 
 interface IRecordButtonProps {
-  recorder: AudioRecorder | undefined;
+  recorder: AudioRecorder | null;
   isRecording: boolean;
   activeThread: ThreadJson | null;
   showRecordButton: boolean;

--- a/src/components/RecordButton/index.tsx
+++ b/src/components/RecordButton/index.tsx
@@ -72,6 +72,14 @@ const RecordButton: React.FC<IRecordButtonProps> = (
     }
   };
 
+  const toggleRecording = () => {
+    if (props.isRecording) {
+      return stopRecording();
+    } else {
+      if (props.recorder) return startRecording();
+    }
+  };
+
   /* disable context menu from long press event in mobile or tablet devices */
   const disableContextMenu = (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
@@ -88,10 +96,7 @@ const RecordButton: React.FC<IRecordButtonProps> = (
         id="record"
         className={classes.button}
         aria-label="record"
-        onMouseDown={startRecording}
-        onTouchStart={startRecording}
-        onMouseUp={stopRecording}
-        onTouchEnd={stopRecording}
+        onDoubleClick={toggleRecording}
         onContextMenu={disableContextMenu}
       >
         {props.embeddedRecordButton ? '開始錄' : '9up'}

--- a/src/components/RecordButton/index.tsx
+++ b/src/components/RecordButton/index.tsx
@@ -88,8 +88,8 @@ const RecordButton: React.FC<IRecordButtonProps> = (
   const handleTouch = (event: React.TouchEvent<HTMLButtonElement>) => {
     event.preventDefault();
     const now = new Date().getTime();
-    setLatestTapTime(now);
     const isDoubleTap = checkDoubleTap(now);
+    setLatestTapTime(now);
     if (isDoubleTap) {
       return toggleRecording();
     }

--- a/src/components/RecordButton/index.tsx
+++ b/src/components/RecordButton/index.tsx
@@ -29,7 +29,7 @@ interface IRecordButtonProps {
   setDrawerState: (side: DrawerSide, open: boolean) => void;
   setShowRecordButtonState: (showRecordButton: boolean) => void;
   embedRecordButton: (embeddedRecordButton: boolean) => void;
-  setGeolocation: (geolocation?: LocationJson) => void;
+  setGeolocation: (geolocation: LocationJson | null) => void;
 }
 
 const RecordButton: React.FC<IRecordButtonProps> = (
@@ -41,7 +41,7 @@ const RecordButton: React.FC<IRecordButtonProps> = (
 
   const startRecording = () => {
     if (props.recorder && !props.isRecording) {
-      props.setGeolocation();
+      props.setGeolocation(null);
       const pathname = location.pathname.replace('/new', '');
       history.push(pathname);
       props.setDrawerState('bottom', true);
@@ -142,7 +142,7 @@ const mapDispatchToProps = (dispatch: ThunkResult) => {
       dispatch(setShowRecordButtonState(showRecordButton)),
     embedRecordButton: (embeddedRecordButton: boolean) =>
       dispatch(embedRecordButton(embeddedRecordButton)),
-    setGeolocation: (geolocation?: LocationJson) =>
+    setGeolocation: (geolocation: LocationJson | null) =>
       dispatch(setGeolocation(geolocation))
   };
 };

--- a/src/components/RecordButton/index.tsx
+++ b/src/components/RecordButton/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useHistory, useLocation } from 'react-router';
 import clsx from 'clsx';
 import { IconButton } from '@material-ui/core';
@@ -35,6 +35,7 @@ interface IRecordButtonProps {
 const RecordButton: React.FC<IRecordButtonProps> = (
   props: IRecordButtonProps
 ) => {
+  const [latestTapTime, setLatestTapTime] = useState<number>(0);
   const history = useHistory();
   const location = useLocation();
 
@@ -80,6 +81,19 @@ const RecordButton: React.FC<IRecordButtonProps> = (
     }
   };
 
+  const checkDoubleTap = (now: number) => {
+    return now - latestTapTime < 600;
+  };
+
+  const handleTouch = () => {
+    const now = new Date().getTime();
+    setLatestTapTime(now);
+    const isDoubleTap = checkDoubleTap(now);
+    if (isDoubleTap) {
+      return toggleRecording();
+    }
+  };
+
   /* disable context menu from long press event in mobile or tablet devices */
   const disableContextMenu = (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
@@ -97,6 +111,7 @@ const RecordButton: React.FC<IRecordButtonProps> = (
         className={classes.button}
         aria-label="record"
         onDoubleClick={toggleRecording}
+        onTouchStart={handleTouch}
         onContextMenu={disableContextMenu}
       >
         {props.embeddedRecordButton ? '開始錄' : '9up'}

--- a/src/components/RecordButton/index.tsx
+++ b/src/components/RecordButton/index.tsx
@@ -85,7 +85,8 @@ const RecordButton: React.FC<IRecordButtonProps> = (
     return now - latestTapTime < 600;
   };
 
-  const handleTouch = () => {
+  const handleTouch = (event: React.TouchEvent<HTMLButtonElement>) => {
+    event.preventDefault();
     const now = new Date().getTime();
     setLatestTapTime(now);
     const isDoubleTap = checkDoubleTap(now);

--- a/src/components/RecordButton/index.tsx
+++ b/src/components/RecordButton/index.tsx
@@ -24,7 +24,7 @@ interface IRecordButtonProps {
   activeThread: ThreadJson | null;
   showRecordButton: boolean;
   embeddedRecordButton: boolean;
-  setAudio: (audio?: AudioData) => void;
+  setAudio: (audio: AudioData | null) => void;
   setIsRecordingState: (isRecording: boolean) => void;
   setDrawerState: (side: DrawerSide, open: boolean) => void;
   setShowRecordButtonState: (showRecordButton: boolean) => void;
@@ -133,7 +133,7 @@ const mapStateToProps = (state: IRootState) => {
 
 const mapDispatchToProps = (dispatch: ThunkResult) => {
   return {
-    setAudio: (audio?: AudioData) => dispatch(setAudio(audio)),
+    setAudio: (audio: AudioData | null) => dispatch(setAudio(audio)),
     setIsRecordingState: (isRecording: boolean) =>
       dispatch(setIsRecordingState(isRecording)),
     setDrawerState: (side: DrawerSide, open: boolean) =>

--- a/src/components/RecordButton/styles.module.scss
+++ b/src/components/RecordButton/styles.module.scss
@@ -1,6 +1,8 @@
 @import 'css/main';
 
 .record-button {
+  touch-action: manipulation;
+
   /* NORMAL STYLE */
   &.floating {
     margin: 0 auto;

--- a/src/components/VoiceForm/index.tsx
+++ b/src/components/VoiceForm/index.tsx
@@ -22,7 +22,7 @@ interface IVoiceFormProps {
   audio: AudioData | null;
   thread: ThreadJson | null;
   geolocation: LocationJson | null;
-  createThread: (newThread: ThreadJson) => Promise<ThreadJson | undefined>;
+  createThread: (newThread: ThreadJson) => Promise<ThreadJson | null>;
   createVoice: (
     newVoice: VoiceJson,
     audioBlob: Blob

--- a/src/components/VoiceForm/index.tsx
+++ b/src/components/VoiceForm/index.tsx
@@ -19,7 +19,7 @@ import { getTimestampJson } from 'utils/time';
 import classes from './styles.module.scss';
 
 interface IVoiceFormProps {
-  audio: AudioData | undefined;
+  audio: AudioData | null;
   thread: ThreadJson | null;
   geolocation: LocationJson | null;
   createThread: (newThread: ThreadJson) => Promise<ThreadJson | undefined>;

--- a/src/components/VoiceForm/index.tsx
+++ b/src/components/VoiceForm/index.tsx
@@ -21,13 +21,13 @@ import classes from './styles.module.scss';
 interface IVoiceFormProps {
   audio: AudioData | undefined;
   thread: ThreadJson | null;
-  geolocation: LocationJson | undefined;
+  geolocation: LocationJson | null;
   createThread: (newThread: ThreadJson) => Promise<ThreadJson | undefined>;
   createVoice: (
     newVoice: VoiceJson,
     audioBlob: Blob
   ) => Promise<VoiceJson | undefined>;
-  setGeolocation: (geolocation?: LocationJson) => void;
+  setGeolocation: (geolocation: LocationJson | null) => void;
   loadVoices: (threadId: string) => void;
   setShowRecordButtonState: (showRecordButton: boolean) => void;
 }
@@ -84,7 +84,7 @@ const VoiceForm: React.FC<IVoiceFormProps> = (props: IVoiceFormProps) => {
       const voice = await props.createVoice(newVoice, audioBlob);
       const { thread_id } = voice as VoiceJson;
 
-      props.setGeolocation();
+      props.setGeolocation(null);
       const pathname = `${REACT_APP_URL_PREFIX}/${thread_id}`;
       history.push(pathname);
       props.loadVoices(threadId);
@@ -190,7 +190,7 @@ const mapDispatchToProps = (dispatch: ThunkResult) => {
     createThread: (newThread: ThreadJson) => dispatch(createThread(newThread)),
     createVoice: (newVoice: VoiceJson, audioBlob: Blob) =>
       dispatch(createVoice(newVoice, audioBlob)),
-    setGeolocation: (geolocation?: LocationJson) =>
+    setGeolocation: (geolocation: LocationJson | null) =>
       dispatch(setGeolocation(geolocation)),
     loadVoices: (threadId: string) => dispatch(loadVoices(threadId)),
     setShowRecordButtonState: (showRecordButton: boolean) =>

--- a/src/redux/audios/actions.ts
+++ b/src/redux/audios/actions.ts
@@ -1,6 +1,6 @@
 import { AudioRecorder, AudioData } from 'utils/audioRecorder';
 
-export function setRecorder(recorder?: AudioRecorder) {
+export function setRecorder(recorder: AudioRecorder | null) {
   return {
     type: 'SET_RECORDER' as 'SET_RECORDER',
     recorder

--- a/src/redux/audios/actions.ts
+++ b/src/redux/audios/actions.ts
@@ -7,7 +7,7 @@ export function setRecorder(recorder: AudioRecorder | null) {
   };
 }
 
-export function setAudio(audio?: AudioData) {
+export function setAudio(audio: AudioData | null) {
   return {
     type: 'SET_AUDIO' as 'SET_AUDIO',
     audio

--- a/src/redux/audios/reducer.ts
+++ b/src/redux/audios/reducer.ts
@@ -2,7 +2,7 @@ import { IAudiosState } from './state';
 import { IAudiosAction } from './actions';
 
 const initialState: IAudiosState = {
-  recorder: undefined,
+  recorder: null,
   audio: undefined,
   isRecording: false
 };

--- a/src/redux/audios/reducer.ts
+++ b/src/redux/audios/reducer.ts
@@ -3,7 +3,7 @@ import { IAudiosAction } from './actions';
 
 const initialState: IAudiosState = {
   recorder: null,
-  audio: undefined,
+  audio: null,
   isRecording: false
 };
 

--- a/src/redux/audios/state.ts
+++ b/src/redux/audios/state.ts
@@ -2,6 +2,6 @@ import { AudioRecorder, AudioData } from 'utils/audioRecorder';
 
 export interface IAudiosState {
   recorder: AudioRecorder | null;
-  audio: AudioData | undefined;
+  audio: AudioData | null;
   isRecording: boolean;
 }

--- a/src/redux/audios/state.ts
+++ b/src/redux/audios/state.ts
@@ -1,7 +1,7 @@
 import { AudioRecorder, AudioData } from 'utils/audioRecorder';
 
 export interface IAudiosState {
-  recorder: AudioRecorder | undefined;
+  recorder: AudioRecorder | null;
   audio: AudioData | undefined;
   isRecording: boolean;
 }

--- a/src/redux/geolocation/actions.ts
+++ b/src/redux/geolocation/actions.ts
@@ -1,6 +1,6 @@
 import { LocationJson } from 'models';
 
-export function setGeolocation(geolocation?: LocationJson) {
+export function setGeolocation(geolocation: LocationJson | null) {
   return {
     type: 'SET_GEOLOCATION' as 'SET_GEOLOCATION',
     geolocation

--- a/src/redux/geolocation/reducer.ts
+++ b/src/redux/geolocation/reducer.ts
@@ -2,7 +2,7 @@ import { IGeolocationState } from './state';
 import { IGeolocationAction } from './actions';
 
 const initialState: IGeolocationState = {
-  geolocation: undefined
+  geolocation: null
 };
 
 export const geolocationReducer = (

--- a/src/redux/geolocation/state.ts
+++ b/src/redux/geolocation/state.ts
@@ -1,5 +1,5 @@
 import { LocationJson } from 'models';
 
 export interface IGeolocationState {
-  geolocation: LocationJson | undefined;
+  geolocation: LocationJson | null;
 }

--- a/src/redux/threads/thunks.ts
+++ b/src/redux/threads/thunks.ts
@@ -37,6 +37,7 @@ export function createThread(newThread: ThreadJson) {
       return data as ThreadJson;
     } else {
       dispatch(failed('CREATE_THREAD_FAILED', data));
+      return null;
     }
   };
 }

--- a/src/utils/audioRecorder.ts
+++ b/src/utils/audioRecorder.ts
@@ -14,7 +14,7 @@ export const audioRecorder = () =>
       audio: true
     });
     const mediaRecorder: MediaRecorder = new MediaRecorder(stream);
-    let audioChunk: Blob | undefined;
+    let audioChunk: Blob;
 
     const dataAvailableHandler = (event: BlobEvent) => {
       audioChunk = event.data;

--- a/src/utils/geolocation.ts
+++ b/src/utils/geolocation.ts
@@ -27,5 +27,5 @@ function positionToLocationJson(position: Position) {
 
 export async function getLocationJson() {
   const position = await getGeolocation();
-  return position ? positionToLocationJson(position) : undefined;
+  return position ? positionToLocationJson(position) : null;
 }


### PR DESCRIPTION
### Descriptions
- Change record gesture to double click to start / stop recording

### Stories
- [x] Create `toggleRecording` method and change event listeners to `onDoubleClick` in `RecordButton`
- [x] Create `latestTapTime` state with `useState` hook and Create `handleTouch` and `checkDoubleTap` methods to capture `touchstart` event in `RecordButton`
- [x] Set `touch-action` to `manipulation` in `record-button` style
- [x] Call `event.preventDefault` in `handleTouch` in `RecordButton`
- [x] Change `geolocation` type to `LocationJson | null`
- [x] Change `recorder` type to `AudioRecorder | null`
- [x] Change `audio` type to `AudioData | null`
- [x] Return `null` when `isSuccess` is `false` in `createThread`
- [x] Remove `undefined` type from `audioChunk`
- [x] Remove `mousedown` event listener and Move the route change logic into `popupOpenHandler` in `Map`