### PR TITLE
Enh/enlarge thread marker

### DIFF
--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -79,7 +79,10 @@ const Map: React.FC<IMapProps> = ({
   /* create thread popups and markers */
   useEffect(() => {
     (layerRef.current as L.LayerGroup).clearLayers();
-    const icon: L.DivIcon = L.divIcon({ className: classes.thread });
+    const icon: L.DivIcon = L.divIcon({
+      className: classes.thread,
+      iconSize: [25, 25]
+    });
 
     threads.forEach(thread => {
       const position = L.latLng([

--- a/src/components/Map/styles.module.scss
+++ b/src/components/Map/styles.module.scss
@@ -9,14 +9,20 @@
   }
 
   .thread {
-    background-color: rgba(get-color(white), 0.9);
     border-radius: 50%;
-    box-shadow: inset 0px 0px 3px 3px get-color(gold), 0px 0px 5px 5px rgba(get-color(gold), 0.9);
-    transform-origin: center;
     outline: none;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
-    &:active {
-      zoom: 1;
+    &:before {
+      content: '';
+      width: 15px;
+      height: 15px;
+      background-color: rgba(get-color(white), 0.9);
+      border-radius: 50%;
+      box-shadow: inset 0px 0px 3px 3px get-color(gold), 0px 0px 5px 5px rgba(get-color(gold), 0.9);
+      transform-origin: center;
     }
   }
 


### PR DESCRIPTION
### Stories
- Enlarge thread marker on Map

### Descriptions 
- [x] Set `iconSize` to `25px` for `thread` markers on `Map`
- [x] Create pseudo-element for `thread` class to adjust `marker` style