### PR TITLE
Feat/recording timer

### DIFF
--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -33,7 +33,7 @@ const Main: React.FC<IMainProps> = (props: IMainProps) => {
 
       <DrawerContainer side="bottom" disableSwipe={props.activeThread === null}>
         {props.isRecording ? (
-          <TimerBar />
+          <TimerBar limit={props.activeThread ? 900 : 9900} />
         ) : (
           <Switch>
             <Route

--- a/src/components/TimerBar/index.tsx
+++ b/src/components/TimerBar/index.tsx
@@ -1,12 +1,55 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
+import { setIsRecordingState } from 'redux/audios/actions';
+import { IRootState, ThunkResult } from 'store';
 import classes from './styles.module.scss';
 
-const TimerBar: React.FC = () => {
+interface ITimerBarProps {
+  limit: number;
+  setIsRecordingState: (isRecording: boolean) => void;
+}
+
+const TimerBar: React.FC<ITimerBarProps> = (props: ITimerBarProps) => {
+  const [centisecond, setCentisecond] = useState<number>(0);
+
+  /* Set interval timer */
+  const timer = setInterval(() => {
+    if (centisecond >= props.limit) return props.setIsRecordingState(false);
+
+    setCentisecond(centisecond + 1);
+  }, 10);
+
+  /* Display the second and the centisecond separately */
+  const displayDigits = (number: number, startIndex: number, endIndex?: number) => number.toString().padStart(4, '0').substring(startIndex, endIndex);
+
+  /* Clear interval timer before TimerBar unmounts */
+  useEffect(() => () => clearInterval(timer));
+
   return (
     <div className={classes['timer-bar']}>
-      <h2 className={classes.timer}>00:00</h2>
+      <h2 className={classes.timer}>
+        <span className={classes.second}>
+          {displayDigits(centisecond, 0, 2)}
+        </span>
+
+        <span className={classes.colon}>:</span>
+
+        <span className={classes.centisecond}>
+          {displayDigits(centisecond, 2)}
+        </span>
+      </h2>
     </div>
   );
 };
 
-export default TimerBar;
+const mapStateToProps = (state: IRootState) => {
+  return {};
+};
+
+const mapDispatchToProps = (dispatch: ThunkResult) => {
+  return {
+    setIsRecordingState: (isRecording: boolean) => dispatch(setIsRecordingState(isRecording))
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(TimerBar);

--- a/src/components/TimerBar/styles.module.scss
+++ b/src/components/TimerBar/styles.module.scss
@@ -6,5 +6,19 @@
     font-weight: normal;
     @include font-size-small;
     text-align: center;
+
+    span {
+      text-align: center;
+      display: inline-block;
+
+      &.second,
+      &.centisecond {
+        width: 20px;
+      }
+
+      &.colon {
+        width: 10px;
+      }
+    }
   }
 }

--- a/src/utils/customHooks.ts
+++ b/src/utils/customHooks.ts
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from "react";
+
+/* Create custom effect hook useDidUpdateEffect to skip the effect from running in the initial render */
+export function useDidUpdateEffect(fn: React.EffectCallback, inputs?: React.DependencyList) {
+  const didMountRef = useRef<Boolean>(false);
+
+  useEffect(() => {
+    if (didMountRef.current) fn();
+    else didMountRef.current = true;
+  }, inputs); /* eslint-disable-line */
+}


### PR DESCRIPTION
### Descriptions
- Set timer in `TimerBar` to limit the recording time
- Refs: [didUpdate custom hook](https://stackoverflow.com/questions/53179075/with-useeffect-how-can-i-skip-applying-an-effect-upon-the-initial-render)

### Stories
- [x] Create `useDidUpdateEffect` in `customHooks` util
- [x] Call `useDidUpdateEffect` hook in `RecordButton` and Use `isRecording` state to control the start and stop of the recording process
- [x] Refactor `TimerBar` to limit the recording time
- [x] Add `limit` prop to `TimerBar` in `Main`